### PR TITLE
Revert to using the correct UTC time for rails

### DIFF
--- a/lib/grizzled/rails/logger.rb
+++ b/lib/grizzled/rails/logger.rb
@@ -146,7 +146,7 @@ Backtrace:
             message = flattened_message if flatten
           end
 
-          time = Time.current.strftime(Configuration.timeformat)
+          time = Time.current.utc.strftime(Configuration.timeformat)
           pid = $$.to_s
           sev = SEVERITIES[severity].to_s
 


### PR DESCRIPTION
I originally made this change a year ago when we were preparing for timezone
changes, and it made sense at the time.  However, now we're expanding into
international territories, it would be better to use UTC as standard instead.
